### PR TITLE
add flake-compat and a default overlay for consumption in non-flake projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/**/.pnp.loader.mjs
 **/.yarn/unplugged
 **/.yarn/install-state.gz
 tsconfig.tsbuildinfo
+test/workspace/.yarn/cache

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1667318659,
@@ -18,6 +34,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,10 @@
   inputs = {
     nixpkgs.url = github:nixos/nixpkgs/nixos-22.05;
     utils.url = github:numtide/flake-utils;
+    flake-compat ={
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
 
   outputs = inputs@{ self, nixpkgs, utils, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
   };
 
   outputs = inputs@{ self, nixpkgs, utils, ... }:
-    utils.lib.eachDefaultSystem (system:
+    (utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
@@ -25,6 +25,7 @@
       rec {
         packages = {
           yarn-plugin = pkgs.callPackage ./yarnPlugin.nix {};
+          yarnBerry = pkgs.yarnBerry;
         };
         lib = {
           mkYarnPackagesFromManifest = (import ./lib/mkYarnPackage.nix { defaultPkgs = pkgs; lib = pkgs.lib; }).mkYarnPackagesFromManifest;
@@ -33,5 +34,14 @@
           inherit pkgs;
         };
       }
-    );
+    ))
+    //
+    {
+      overlays.default = (final: prev: {
+        yarnBerry = final.callPackage ./yarn.nix {};
+        yarn-plugin-yarnpnp2nix = final.callPackage ./yarnPlugin.nix {};
+        yarnpnp2nixLib = import ./lib/mkYarnPackage.nix { defaultPkgs = final; lib = final.lib; };
+      });
+    }
+  ;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,11 @@
         packages = {
           yarn-plugin = pkgs.yarn-plugin-yarnpnp2nix;
           yarnBerry = pkgs.yarnBerry;
+          yarnpnp2nix-test = pkgs.writeShellApplication {
+            name = "yarnpnp2nix-test";
+            runtimeInputs = [ pkgs.jq ];
+            text = builtins.readFile ./runTests.sh;
+          };
         };
         lib = pkgs.yarnpnp2nixLib;
         devShell = import ./shell.nix {

--- a/runTests.sh
+++ b/runTests.sh
@@ -8,23 +8,23 @@ pushd test
 
 nix eval --json .#packages.aarch64-darwin.testa.transitiveRuntimePackages
 
-nix build -L .#packages.$system.testb
+nix build -L ".#packages.$system.testb"
 ./result/bin/testb
 
-nix build -L .#packages.$system.testa
+nix build -L ".#packages.$system.testa"
 ./result/bin/testa-peer-test
 
-nix build -L .#packages.$system.testb.package
+nix build -L ".#packages.$system.testb.package"
 testbPackage=$(realpath ./result)/node_modules/testb
 
-nix build -L .#packages.$system.testb.shellRuntimeEnvironment
+nix build -L ".#packages.$system.testb.shellRuntimeEnvironment"
 runShellEnvironmentTest=$(realpath ./result)
 
-pushd $testbPackage
-$runShellEnvironmentTest/bin/testa-test
+pushd "$testbPackage"
+"$runShellEnvironmentTest/bin/testa-test"
 popd
 
-nix develop .#packages.$system.testb -c bash <<EOF
+nix develop ".#packages.$system.testb" -c bash <<EOF
 cd $testbPackage
 testa-test
 EOF

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1644229661,
@@ -73,6 +89,7 @@
     },
     "yarnpnp2nix": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -80,12 +97,12 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-Usf2dbsXaB6xkICX4P5nt8CBdR4JjxRpJz9stkTvm7A=",
-        "path": "/nix/store/pdwibaa25n6123w13w7lw29nf5kw59lg-source",
+        "narHash": "sha256-millAlN1yr3622zO+UXFhCxC6ygSQKJn1eCZNTccD3w=",
+        "path": "/nix/store/al43ad5bjjzm1y0k2zv2jxyg6qdknjal-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/pdwibaa25n6123w13w7lw29nf5kw59lg-source",
+        "path": "/nix/store/al43ad5bjjzm1y0k2zv2jxyg6qdknjal-source",
         "type": "path"
       }
     }

--- a/test/flake.lock
+++ b/test/flake.lock
@@ -97,12 +97,12 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-millAlN1yr3622zO+UXFhCxC6ygSQKJn1eCZNTccD3w=",
-        "path": "/nix/store/al43ad5bjjzm1y0k2zv2jxyg6qdknjal-source",
+        "narHash": "sha256-a6M0K19DCKzBqJUqMHbybYznyyJz7oFyn3SRf/2Bnvk=",
+        "path": "/nix/store/07jn106an40m8capp85gdrw8d4iakxxk-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/al43ad5bjjzm1y0k2zv2jxyg6qdknjal-source",
+        "path": "/nix/store/07jn106an40m8capp85gdrw8d4iakxxk-source",
         "type": "path"
       }
     }


### PR DESCRIPTION
also: 

1. [package runTests.sh with nix](https://github.com/madjam002/yarnpnp2nix/pull/11/commits/abc0349b8f7c41d9640a7be5f3b3cebaca50d55d) so that it works event if user does't have jq installed locally 
2. [gitignore: add test/workspace/.yarn/cache/](https://github.com/madjam002/yarnpnp2nix/pull/11/commits/c2b54eec0025e69aafa0f878777d69df53921fcf)


EDIT: also see [this commit](https://github.com/rhinofi/yarnpnp2nix/commit/e90e70cec9cdbaad638e61b525175678021ed98b), which fixes `shell.nix`, as currently it doesn't work with classic `nix-shell` 

note that the actual devShell is defined in [previous commit](https://github.com/rhinofi/yarnpnp2nix/commit/429e325b680a9ba1247c62adfffd8413fc721644#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L37-R42) on that branch, and uses yarnBerry instead of yarn, as suggested in my [other PR](https://github.com/madjam002/yarnpnp2nix/pull/12). Please let me know if you'd be willing to accept all of these changes in a single PR. Thanks!